### PR TITLE
Use opcode for java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 							<artifactId>maven-compiler-plugin</artifactId>
 							<version>3.1</version>
 							<configuration>
-									<source>1.5</source>
-									<target>1.5</target>
+									<source>1.7</source>
+									<target>1.7</target>
 							</configuration>
 						</plugin>
 			<!-- Disable resources (project has none) -->

--- a/src/com/esotericsoftware/reflectasm/ConstructorAccess.java
+++ b/src/com/esotericsoftware/reflectasm/ConstructorAccess.java
@@ -49,7 +49,7 @@ public abstract class ConstructorAccess<T> {
 		String accessClassName = className + "ConstructorAccess";
 		if (accessClassName.startsWith("java.")) accessClassName = "reflectasm." + accessClassName;
 		Class accessClass;
-		
+
 		AccessClassLoader loader = AccessClassLoader.get(type);
 		synchronized (loader) {
 			try {
@@ -90,7 +90,7 @@ public abstract class ConstructorAccess<T> {
 												"com/esotericsoftware/reflectasm/ConstructorAccess";
 
 				ClassWriter cw = new ClassWriter(0);
-				cw.visit(V1_1, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, superclassNameInternal, null);
+				cw.visit(V1_7, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, superclassNameInternal, null);
 
 				insertConstructor(cw, superclassNameInternal);
 				insertNewInstance(cw, classNameInternal);

--- a/src/com/esotericsoftware/reflectasm/FieldAccess.java
+++ b/src/com/esotericsoftware/reflectasm/FieldAccess.java
@@ -129,7 +129,7 @@ public abstract class FieldAccess {
 				String classNameInternal = className.replace('.', '/');
 
 				ClassWriter cw = new ClassWriter(0);
-				cw.visit(V1_1, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, "com/esotericsoftware/reflectasm/FieldAccess",
+				cw.visit(V1_7, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, "com/esotericsoftware/reflectasm/FieldAccess",
 					null);
 				insertConstructor(cw);
 				insertGetObject(cw, classNameInternal, fields);

--- a/src/com/esotericsoftware/reflectasm/MethodAccess.java
+++ b/src/com/esotericsoftware/reflectasm/MethodAccess.java
@@ -116,7 +116,7 @@ public abstract class MethodAccess {
 
 				ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
 				MethodVisitor mv;
-				cw.visit(V1_1, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, "com/esotericsoftware/reflectasm/MethodAccess",
+				cw.visit(V1_7, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, "com/esotericsoftware/reflectasm/MethodAccess",
 					null);
 				{
 					mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);


### PR DESCRIPTION
We were seeing `java.lang.IllegalArgumentException: Class versions V1_5 or less must use F_NEW frames.` with asm 7.2 and this seems to fix things. I can't say that I totally understand these changes.

I also don't understand why the build is currently failing on blazar.

@jhaber @kmclarnon